### PR TITLE
Fix a typo in chapter_tensor_program/case_study.py

### DIFF
--- a/chapter_tensor_program/case_study.md
+++ b/chapter_tensor_program/case_study.md
@@ -384,7 +384,7 @@ IPython.display.Code(MyModule.script(), language="python")
 Now we are ready to try out the code transformations, we begin by creating a `Schedule` helper class with the given MyModule as input.
 
 ```{.python .input n=11}
-sch = tvm.tir.Schedule(MyModule)
+sch = tvm.tir.Schedule(MyModuleWithAxisRemapSugar)
 ```
 
 Then we perform the following operations to obtain a reference to block Y and corresponding loops.


### PR DESCRIPTION
The func "mm_relu" is defined in MyModuleWithAxisRemapSugar. Otherwise, running `block_Y = sch.get_block("Y", func_name="mm_relu")` yields "ValueError: Cannot find global var "mm_relu" in the Module"