### PR TITLE
add models.html to deploy skip list

### DIFF
--- a/static/update_site.py
+++ b/static/update_site.py
@@ -14,6 +14,7 @@ def py_str(cstr):
 # list of files to skip
 skip_list = set(
     [
+        "models.html",
         "wheels.html",
         ".gitignore",
         ".nojekyll",


### PR DESCRIPTION
This PR adds models.html, which will be used for display all available models in MLC, to the skip list so the site update actions won't overwrite it by mistake.