### PR TITLE
Fix image rendering: add missing alt tags

### DIFF
--- a/chapter_auto_program_optimization/index.md
+++ b/chapter_auto_program_optimization/index.md
@@ -145,7 +145,7 @@ def stochastic_schedule_mm(sch: tvm.tir.Schedule):
     return sch
 ```
 
-![](../img/auto_prog_optim_stoch_sch_transformation.png)
+![`stochastic_schedule_mm` vs `schedule_mm`](../img/auto_prog_optim_stoch_sch_transformation.png)
 
 Let us compare `stochastic_schedule_mm` and `schedule_mm` side by side. We can find that the only difference is how to specify `j_factors`. In the case of `schedule_mm`, `j_factors` is passed in as a parameter specified by us. In the case of `stochastic_schedule_mm`, it comes from `sch.sample_perfect_tile`.
 
@@ -244,7 +244,7 @@ IPython.display.HTML(code2html(sch.mod.script()))
 
 One thing that you might realize is that `stochastic_schedule_mm` create a **search space of possible programs** depending on the specific decisions made at each sampling step.
 
-![](../img/auto_prog_optim_transformation_search.png)
+![Stochastic transformation search](../img/auto_prog_optim_transformation_search.png)
 
 Coming back to our initial intuition, we want to be able to specify a set of **possible programs**  instead of one program. `stochastic_schedule_mm` did exactly that. Of course, one natural question to ask next is what is the best choice.
 
@@ -410,7 +410,7 @@ We also download pre-packed model parameters that we will use in our examples.
 !wget -nc https://github.com/mlc-ai/web-data/raw/main/models/fasionmnist_mlp_params.pkl
 ```
 
-![](../img/e2e_fashionmnist_mlp_model.png)
+![FashionMNIST MLP model](../img/e2e_fashionmnist_mlp_model.png)
 
 As a reminder, the above figure shows the model of interest.
 
@@ -508,7 +508,7 @@ print("MyModuleWithParams time-cost: %g ms" % (ftimer(data_nd).mean * 1000))
 
 We are now ready to tune the `linear0`. Our overall process is summarized in the following diagram.
 
-![](../img/auto_prog_optim_optim_flow.png)
+![Optimization flow](../img/auto_prog_optim_optim_flow.png)
 
 Currently, tune API only takes an IRModule with one `main` function, so we first get the `linear0` out into another module's main function and pass it to tune
 
@@ -567,7 +567,7 @@ Importantly, putting the search result back into the end-to-end flow is just a m
 
 So we again are following the generic MLC process in the figure below. In future lectures, we will introduce more kinds of transformations on primitive functions and computational graph functions. A good MLC process composes these transformations together to form an end deployment form.
 
-![](../img/mlc_process.png)
+![MLC process](../img/mlc_process.png)
 
 ## Summary
 

--- a/chapter_end_to_end/index.md
+++ b/chapter_end_to_end/index.md
@@ -2,7 +2,7 @@
 
 ## Prelude
 
-![](../img/tensor_func_linear_relu.png)
+![Linear ReLU transformation](../img/tensor_func_linear_relu.png)
 
 Most of the MLC process can be viewed as transformation among tensor functions. The main thing we aim to answer in our following up are:
 
@@ -69,7 +69,7 @@ print("Class:", class_names[label[0]])
 
 In this chapter, we will use the following model as an example. This is a two-layer neural network that consists of two linear operations with relu activation. To keep things simple, we removed the final softmax layer. The output score is un-normalized, but still, the maximum value corresponds to the most likely class.
 
-![](../img/e2e_fashionmnist_mlp_model.png)
+![FashionMNIST MLP model](../img/e2e_fashionmnist_mlp_model.png)
 
 Let us begin by reviewing a Numpy implementation of the model.
 
@@ -221,11 +221,11 @@ The above code contains kinds of functions: the primitive tensor functions (`T.p
 
 Again it is helpful to see the TVMScript code and low-level numpy code side-by-side and check the corresponding elements, and we are going to walk through each of them in detail. Since we already learned about primitive tensor functions, we are going to focus on the high-level execution part.
 
-![](../img/e2e_compare_to_lnumpy.png)
+![TVMScript vs low-level NumPy](../img/e2e_compare_to_lnumpy.png)
 
 ### Computational Graph View
 
-![](../img/e2e_computational_graph_call_tir.png)
+![TensorIR computational graph](../img/e2e_computational_graph_call_tir.png)
 
 It is usually helpful to use graph to visualize high-level model executions. The above figure is a graph-view of the `main` function:
 
@@ -279,7 +279,7 @@ def lnumpy_mlp(data, w0, b0, w1, b1):
     return out
 ```
 
-![](../img/e2e_computational_graph_numpy.png)
+![NumPy computational graph](../img/e2e_computational_graph_numpy.png)
 
 We can certainly try a bit :) The above figure is one possible "failed attempt" to fit the `lnumpy_mlp` into a "computational graph-like" form by simply connecting function inputs to the function.
 
@@ -589,7 +589,7 @@ In this chapter, we have discussed many ways to describe the end-to-end model ex
 
 So far, we have touched on a few ways to transform the end-to-end IRModule (e.g. parameter binding). Let us come back to the following common theme of MLC: MLC process is about representing the execution in possibly different abstractions and transforming among them.
 
-![](../img/mlc_process.png)
+![MLC process](../img/mlc_process.png)
 
 There are many possible transformations in the end-to-end execution. For example, we can take the TensorIR function in MyModuleMixture and change the `linear0` function using the schedule operations taught in the last lecture. In other instances, we might want to transform high-level model executions into a mixture of library function calls and TensorIR functions.
 

--- a/chapter_gpu_acceleration/part1.md
+++ b/chapter_gpu_acceleration/part1.md
@@ -28,11 +28,11 @@ import numpy as np
 
 Let us begin by reviewing what a GPU architecture looks like. A typical GPU contains a collection of stream multi-processors, and each multi-processor has many cores. A GPU device is massively parallel and allows us to execute many tasks concurrently.
 
-![](../img/gpu_arch.png)
+![GPU Architecture](../img/gpu_arch.png)
 
 To program a GPU, we need to create a set of thread blocks, with each thread mapping to the cores and the thread block map to the stream multiprocessors.
 
-![](../img/gpu_stream_processors.png)
+![GPU stream processors](../img/gpu_stream_processors.png)
 
 Let us start GPU programming using a vector add example. The following TensorIR program takes two vectors, A and B, performs element-wise add, and stores the result in C.
 
@@ -64,7 +64,7 @@ sch.mod.show()
 
 Then we bind the iterators to the GPU thread blocks. Each thread is parameterized by two indices -- `threadIdx.x` and `blockIdx.x`. In practice, we can have multiple dimensional thread indices, but we keep them simple as one dimension.
 
-![](../img/gpu_thread_blocks.png)
+![GPU Thread Blocks](../img/gpu_thread_blocks.png)
 
 ```{.python .input}
 sch.bind(i0, "blockIdx.x")
@@ -95,7 +95,7 @@ print(C_nd)
 
 Now, let us move forward to another example -- window sum. This program can be viewed as a basic version of "convolution" with a predefined weight `[1,1,1]`. We are taking sliding over the input and add three neighboring values together.
 
-![](../img/window_sum.png)
+![Window sum](../img/window_sum.png)
 
 ```{.python .input}
 @tvm.script.ir_module
@@ -123,7 +123,7 @@ sch.bind(i1, "threadIdx.x")
 sch.mod.show()
 ```
 
-![](../img/gpu_stream_processors.png)
+![GPU stream processors](../img/gpu_stream_processors.png)
 
 Importantly, in this case, there are reuse opportunities. Remember that each GPU thread block contains shared memory that all threads can access within the block. We use `cache_read` to add an intermediate stage that caches segments (in green below) onto the shared memory. After the caching is finished, the threads can then read from the shared memory.
 
@@ -187,7 +187,7 @@ class MyModuleMatmul:
 
 #### Local Blocking
 
-![](../img/gpu_local_blocking.png)
+![GPU Local Blocking](../img/gpu_local_blocking.png)
 
 To increase overall memory reuse. We can tile the loops. In particular, we introduce local tiles such that we only need to load stripe of data from A and B once, then use them to perform a `V * V` matrix multiplication result.
 
@@ -243,7 +243,7 @@ print("GEMM-Blocking: %f GFLOPS" % (num_flop / evaluator(A_nd, B_nd, C_nd).mean 
 
 ### Shared Memory Blocking
 
-![](../img/gpu_shared_blocking.png)
+![GPU Shared Memory Blocking](../img/gpu_shared_blocking.png)
 
 Our first attempt did not consider the neighboring threads which sit in the same GPU thread block, and we can load the data they commonly need into a piece of shared memory.
 

--- a/chapter_gpu_acceleration/part2.md
+++ b/chapter_gpu_acceleration/part2.md
@@ -16,7 +16,7 @@ import numpy as np
 
 ### Hardware Specialization Trend
 
-![](../img/hardware_specialization.png)
+![Hardware Specialization Trend](../img/hardware_specialization.png)
 
 If we look at the machine learning hardware landscape, one emerging theme recently is specialization. Traditionally, we build our solutions on generic scalar processors, where we can perform operations on one floating point at a time. The vector instructions set such as AVX and ARM/Neon provide effective ways to speed up our programs but also bring some complexities to how we write the programs.
 
@@ -52,7 +52,7 @@ def lnumpy_tmm(A: np.ndarray, B: np.ndarray, C: np.ndarray):
             accel_dma_copy(C[i * 16 : i * 16 + 16, j * 16 : j * 16 + 16], C_accumulator[:,:])
 ```
 
-![](../img/hardware_specialization_abc.png)
+![Data flow across specialized hardware memory regions](../img/hardware_specialization_abc.png)
 
 The above low-level NumPy program contains the following key elements:
 
@@ -205,7 +205,7 @@ sch.reverse_compute_at(write_back_block, j)
 sch.mod.show()
 ```
 
-![](../img/hardware_specialization_abc.png)
+![Data flow across specialized hardware memory regions](../img/hardware_specialization_abc.png)
 
 Here `global.A_reg` contains two parts. `global` indicates that all threads can globally access the memory, and `A_reg` is a **scope tag** of the memory, which provides opportunities for follow-up compilation to map it to special regions such as registers.
 

--- a/chapter_graph_optimization/index.md
+++ b/chapter_graph_optimization/index.md
@@ -4,7 +4,7 @@
 
 Most of the MLC process can be viewed as transformation among tensor functions. In the past chapters, we studied how to transform each primitive tensor functions individually. In this chapter, let us talk about high-level transformations among computational graphs.
 
-![](../img/mlc-elem-transform.png)
+![Example MLC Process as Tensor Function Transformations.](../img/mlc-elem-transform.png)
 
 ## Preparations
 
@@ -101,7 +101,7 @@ And its value field corresponds to the right-hand side of the binding. Each valu
 binding.value
 ```
 
-![](../img/relax_func_data_structure.png)
+![`relax` function data structure](../img/relax_func_data_structure.png)
 
 The above figure summarizes the data structure involved in this particular function.
 
@@ -397,7 +397,7 @@ Real-world MLC process can contain more powerful and robust transformations. For
 
 Notably, each of these transformations is composable with each other. For example, we can choose to use our version of customized fusor to support additional new fusion patterns that we want to explore and then feed into an existing fusor to handle the rest of the steps.
 
-![](../img/mlc_process.png)
+![MLC process](../img/mlc_process.png)
 
 ## Summary
 

--- a/chapter_integration/index.md
+++ b/chapter_integration/index.md
@@ -155,7 +155,7 @@ MyModule.show()
 
 Now let us do a deep dive into each block builder API. It is helpful to put the block builder code and the resulting module side by side.
 
-![](../img/integration_block_builder.png)
+![Block builder code and the resulting module](../img/integration_block_builder.png)
 
 The block builder comes with scopes that correspond to the scopes in the relax function. For example, `bb.dataflow()` creates a dataflow
 block where all the block builder calls inside the scope belonging to the dataflow scope.
@@ -385,7 +385,7 @@ print("Class:", class_names[label[0]])
 !wget -nc https://github.com/mlc-ai/web-data/raw/main/models/fasionmnist_mlp_params.pkl
 ```
 
-![](../img/e2e_fashionmnist_mlp_model.png)
+![FashionMNIST MLP model](../img/e2e_fashionmnist_mlp_model.png)
 
 The above is our model of interest, we can build the PyTorch model as follows.
 
@@ -508,7 +508,7 @@ In this chapter, we focus on the **develop** part of the MLC flow. We studied di
 
 Once we get the model into the IRModule, we can introduce more kinds of transformations on primitive functions and computational graph functions. A good MLC process composes these transformations together to form an end deployment form.
 
-![](../img/mlc_process.png)
+![MLC process](../img/mlc_process.png)
 
 ## Summary
 

--- a/chapter_tensor_program/case_study.md
+++ b/chapter_tensor_program/case_study.md
@@ -10,7 +10,7 @@ python -m pip install --pre -U -f https://mlc.ai/wheels mlc-ai-nightly-cpu
 
 ### Prelude
 
-![](../img/tensor_func_linear_relu.png)
+![Linear ReLU transformation](../img/tensor_func_linear_relu.png)
 
 To begin today's lecture, let us recap the key principle of the MLC process. Most of the MLC process can be viewed as transformation among tensor functions. The main thing we aim to answer in our following up are:
 
@@ -120,7 +120,7 @@ class MyModule:
 
 It is helpful to be able to see the numpy code and the TensorIR code side-by-side and check the corresponding elements, and we are going to walk through each of them in detail.
 
-![](../img/tensor_func_and_numpy.png)
+![TensorIR vs NumPy](../img/tensor_func_and_numpy.png)
 
 Let us first start by reviewing elements that have a direct correspondence between the numpy and TensorIR side. Then we will come back and review additional elements that are not part of the numpy program.
 
@@ -212,7 +212,7 @@ Let us walk through those property one by one.  First of all, in terms of the bo
 Let us now start to take a closer look at the block axis properties. These axis properties marks the relation of the axis to the computation being performed.
 The figure below summarizes the block (iteration) axes and the read write relations of block Y. Note that strictly speaking the block is doing (reduction) updates to `Y`, we mark this as write for now as we don't need value of `Y` from another block.
 
-![](../img/tensor_ir_block_axis.png)
+![TensorIR block axis](../img/tensor_ir_block_axis.png)
 
 In our example, block Y computes the result `Y[vi, vj]` by reading values from `A[vi, vk]` and `B[vk, vj]` and perform sum over all possible `vk`. In this particular example, if we fix `vi`, `vj` to be `(0, 1)`, and run the block for `vk in range(0, 128)`, we can effectively compute `C[0, 1]` independently from other possible locations (that have different values of vi, vj).
 
@@ -525,14 +525,14 @@ IPython.display.Code(MyModule.script(), language="python")
 IPython.display.Code(sch.mod.script(), language="python")
 ```
 
-![](../img/cpu_arch.png)
+![Memory hierarchy in computer architecture](../img/cpu_arch.png)
 
 To see why different loop variants result in different performances, we need to review the fact that it is not uniformly fast to access any piece of memory in `A` and `B`. Modern CPU comes with multiple levels of caches, where data needs to be fetched into the cache before the CPU can access it.
 
 Importantly, it is much faster to access the data already in the cache. One strategy that CPU takes is to fetch data closer to each other. When we read one element in the memory, it will attempt to fetch the elements close by (formally known as cache-line) to the cache. So when you read the next element, it is already in the cache. As a result, code with continuous memory access is usually faster than code that randomly accesses different parts of the memory.
 
 
-![](../img/tensor_func_loop_order.png)
+![Tensor function loop order](../img/tensor_func_loop_order.png)
 
 Now let us look at the above visualization of iterations and analyze what is going on.
 In this analysis, let us focus on two inner-most loops: `k` and `j1`. The highlighted cover shows the corresponding region in `Y`, `A` and `B` that the iteration touches when we iterate over `j1` for one specific instance of `k`.
@@ -615,7 +615,7 @@ In practice, we also get TensorIR functions as results of transformations. This 
 
 In this section, let us review what we learned so far. We learned that a common MLC process follows a sequence of program transformations. It is interesting to compare the TensorIR transformation process to the low-level numpy reference development process.
 
-![](../img/standard_process.png)
+![Standard development process](../img/standard_process.png)
 
 The above figure shows the standard development process. We need to repeat the process of developing different program variants and then (build if it is a compiled language) run them on the platform of interest.
 
@@ -623,7 +623,7 @@ The key difference in an MLC process(shown in the figure below) is the programma
 
 Transformation is a very powerful tool that helps us simplify development costs and introduce more automation to the process. This section covered a specific perspective on primitive tensor functions via TensorIR, and we will cover more perspectives in the future.
 
-![](../img/mlc_process.png)
+![MLC process](../img/mlc_process.png)
 
 
 Notably, direct code development and transformations are equally important in practice: We can still leverage a lot of domain expertise to develop and optimize part of the programs and then combine that with transformation-based approaches. We will talk about how to combine the two practices in future chapters.


### PR DESCRIPTION
The book at https://book.mlc.ai and the generated PDF were rendering the wrong images in places due to missing alt text, which is used by d2lbook for the figure captions.

This change adds alt text to all images which did not have it before, thus fixing the rendering issue.

I have made this change before reading the book, as such if there are some captions that I got wrong, I would appreciate corrections!